### PR TITLE
Make it easier for a user to run assignment's tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ npm-debug.log
 tmp
 bin/configlet
 bin/configlet.exe
+
+*/node_modules
+*/traceur-output

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,38 @@
+## Setup
+
+Go through the setup instructions for ECMAScript to
+install the necessary dependencies:
+
+http://help.exercism.io/getting-started-with-ecmascript.html
+
+## Requirements
+
+They are already described in the link above, but just as a
+quick reference:
+
+Install globally a tool to run [Gulp](http://gulpjs.com) if
+it is not installed yet:
+
+```bash
+$ npm install -g gulp-cli
+```
+
+Install assignment dependencies:
+
+```bash
+$ npm install
+```
+
+## Making the test suite pass
+
+Execute the tests with:
+
+```bash
+$ gulp test
+```
+
+In many test suites all but the first test have been skipped.
+
+Once you get a test passing, you can unskip the next one by
+changing `xit` to `it`.
+

--- a/palindrome-products/gulpfile.js
+++ b/palindrome-products/gulpfile.js
@@ -1,0 +1,46 @@
+var TRACEUR_OUTPUT_DIR = 'traceur-output',
+  gulp = require('gulp'),
+  jasmine = require('gulp-jasmine'),
+  traceur = require('gulp-traceur'),
+  clean = require('gulp-clean');
+
+gulp.task('default', [ 'test' ]);
+ 
+gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+  return gulp.src([ TRACEUR_OUTPUT_DIR + '/*_test.spec.js' ])
+    .pipe(jasmine());
+});
+
+gulp.task('traceur', function () {
+  return gulp.src([ '*.js', '!gulpfile.js', '!example.js' ])
+    .pipe(traceur({
+      modules: 'commonjs',
+
+      // experimental options
+      properTailCalls: true,
+      symbols: true,
+      annotations: true,
+      arrayComprehension: true,
+      asyncFunctions: true,
+      asyncGenerators: true,
+      exponentiation: true,
+      exportFromExtended: true,
+      forOn: true,
+      generatorComprehension: true,
+      memberVariables: true,
+      require: true,
+      types: true
+    }))
+    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+});
+
+gulp.task('copy-runtime', function () {
+  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+});
+
+gulp.task('clean', function () {
+  return gulp.src(TRACEUR_OUTPUT_DIR, { read: false })
+    .pipe(clean());
+});
+

--- a/palindrome-products/package.json
+++ b/palindrome-products/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "assignment",
+  "version": "0.0.1",
+  "description": "Exercism ECMAScript assignment",
+  "scripts": {
+    "test": "gulp test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/xecmascript"
+  },
+  "bugs": {
+    "url": "https://github.com/exercism/xecmascript/issues"
+  },
+  "homepage": "https://github.com/exercism/xecmascript",
+  "devDependencies": {
+    "gulp": "~3.9.0",
+    "gulp-jasmine": "~2.0.1",
+    "gulp-traceur": "~0.17.1",
+    "traceur": "0.0.90",
+    "gulp-clean": "~0.3.1"
+  }
+}

--- a/palindrome-products/palindrome-products.js
+++ b/palindrome-products/palindrome-products.js
@@ -1,0 +1,23 @@
+'use strict';
+exports.generate = generate;
+
+// module imports (remove when es6 features are shipped with Node.js)
+require('./traceur-runtime');
+
+/**
+ * Generate palindrome-products table and calculate largest/smallest.
+ *
+ * @param {Number} [minFactor]
+ * Minimum Factor
+ *
+ * @param {Number} [maxFactor]
+ * Maximum Factor
+ *
+ * @return {{largest: number, smallest: number}}
+ */
+function generate({ minFactor = 1, maxFactor = Number.MAX_VALUE }) {
+//
+// YOUR CODE GOES HERE
+//
+}
+


### PR DESCRIPTION
This pull request includes Node.js dependencies file (`package.json`) and a Gulp file (`gulpfile.js`) that allows the user to run assignment tests with just one command (once all dependencies are installed):

```bash
$ gulp test
```

These files are included in the only existing assignment directory (palindrome-products). Each assignment should have the same files so that there is a common way to run tests for all assignments.

The pull request also includes content for the `SETUP.md` file explaining how to install dependencies and how to run tests. Finally, it modifies `.gitignore` to ignore transpiled JavaScript files (from ES6 to ES5) and tools installed for each assignment.