### PR TITLE
Configure Travis CI to run all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: bash
 script:
   - bin/fetch-configlet
   - bin/configlet .
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # assignments
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|bin|node_modules)$$"
-ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d -exec basename -a {} + | sort | grep -Ev $(IGNOREDIRS))
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | cut -d'/' -f2 | sort | grep -Ev $(IGNOREDIRS))
 
 # output directories
 TMPDIR ?= "/tmp"
@@ -16,7 +16,7 @@ all: test
 
 test-assignment:
 	@printf "\e[4mRunning tests for $(ASSIGNMENT) assignment\e[0m\n"
-	@cp $(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)/$(TSTFILE)
+	@sed 's/xit/it/g' $(ASSIGNMENT)/$(TSTFILE) > $(OUTDIR)/$(TSTFILE)
 	@./node_modules/.bin/traceur --experimental --modules=commonjs --symbols=false --script $(ASSIGNMENT)/$(EXAMPLE) --out $(ASSIGNMENT)/$(ASSIGNMENT).$(FILEEXT)
 	@mv $(ASSIGNMENT)/$(ASSIGNMENT).$(FILEEXT) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@cp ./node_modules/traceur/bin/traceur-runtime.js $(OUTDIR)/traceur-runtime.js

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xECMAScript6 [![Build Status](https://travis-ci.org/exercism/xecmascript6.png?branch=master)](https://travis-ci.org/exercism/xecmascript6)
+# xECMAScript6 [![Build Status](https://travis-ci.org/exercism/xecmascript.png?branch=master)](https://travis-ci.org/exercism/xecmascript6)
 
 > Exercism exercises in ECMAScript 6
 


### PR DESCRIPTION
Configure Travis CI to run the `make test` command that will run
all tests. Jasmine skipped tests are enabled by replacing `xit`
methods by `it` ones.

And the `README.md` file shows correctly the icon about the
Travis build.