### PR TITLE
Improve `gulpfile.js`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ node_modules: package.json
 
 test-assignment: node_modules
 	@printf "\e[4mRunning tests for $(ASSIGNMENT) assignment\e[0m\n"
+	@cp gulpfile.js $(ASSIGNMENT)
 	@sed 's/xit/it/g' $(ASSIGNMENT)/$(TSTFILE) > $(INTDIR)/$(TSTFILE)
 	@cp $(ASSIGNMENT)/$(EXAMPLE) $(INTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@gulp test --input $(INTDIR) --output $(OUTDIR)

--- a/bob/gulpfile.js
+++ b/bob/gulpfile.js
@@ -1,18 +1,36 @@
-var TRACEUR_OUTPUT_DIR = 'traceur-output',
-  gulp = require('gulp'),
+function getInputDirectory(argv) {
+  if (argv.input) {
+    return argv.input;
+  }
+  return '.';
+}
+
+function getOutputDirectory(argv) {
+  if (argv.output) {
+    return argv.output;
+  }
+  return 'traceur-output';
+}
+
+var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
   traceur = require('gulp-traceur'),
-  clean = require('gulp-clean');
+  del = require('del'),
+  argv  = require('yargs').argv,
+  inputDir = getInputDirectory(argv),
+  outputDir = getOutputDirectory(argv);
+
+// Gulp tasks definition
 
 gulp.task('default', [ 'test' ]);
  
 gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
-  return gulp.src([ TRACEUR_OUTPUT_DIR + '/*_test.spec.js' ])
+  return gulp.src([ outputDir + '/*_test.spec.js' ])
     .pipe(jasmine());
 });
 
 gulp.task('traceur', function () {
-  return gulp.src([ '*.js', '!gulpfile.js', '!example.js' ])
+  return gulp.src([ inputDir + '/*.js' ])
     .pipe(traceur({
       modules: 'commonjs',
 
@@ -31,16 +49,15 @@ gulp.task('traceur', function () {
       require: true,
       types: true
     }))
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
 gulp.task('copy-runtime', function () {
   return gulp.src(traceur.RUNTIME_PATH)
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
-gulp.task('clean', function () {
-  return gulp.src(TRACEUR_OUTPUT_DIR, { read: false })
-    .pipe(clean());
+gulp.task('clean', function (cb) {
+  del([ outputDir ], cb);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,18 +1,36 @@
+function getInputDirectory(argv) {
+  if (argv.input) {
+    return argv.input;
+  }
+  return '.';
+}
+
+function getOutputDirectory(argv) {
+  if (argv.output) {
+    return argv.output;
+  }
+  return 'traceur-output';
+}
+
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
   traceur = require('gulp-traceur'),
-  clean = require('gulp-clean'),
-  argv  = require('yargs').argv;
+  del = require('del'),
+  argv  = require('yargs').argv,
+  inputDir = getInputDirectory(argv),
+  outputDir = getOutputDirectory(argv);
+
+// Gulp tasks definition
 
 gulp.task('default', [ 'test' ]);
  
 gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
-  return gulp.src([ argv.output + '/*_test.spec.js' ])
+  return gulp.src([ outputDir + '/*_test.spec.js' ])
     .pipe(jasmine());
 });
 
 gulp.task('traceur', function () {
-  return gulp.src([ argv.input + '/*.js' ])
+  return gulp.src([ inputDir + '/*.js' ])
     .pipe(traceur({
       modules: 'commonjs',
 
@@ -31,16 +49,15 @@ gulp.task('traceur', function () {
       require: true,
       types: true
     }))
-    .pipe(gulp.dest(argv.output));
+    .pipe(gulp.dest(outputDir));
 });
 
 gulp.task('copy-runtime', function () {
   return gulp.src(traceur.RUNTIME_PATH)
-    .pipe(gulp.dest(argv.output));
+    .pipe(gulp.dest(outputDir));
 });
 
-gulp.task('clean', function () {
-  return gulp.src(argv.output, { read: false })
-    .pipe(clean());
+gulp.task('clean', function (cb) {
+  del([ outputDir ], cb);
 });
 

--- a/hello-world/gulpfile.js
+++ b/hello-world/gulpfile.js
@@ -1,18 +1,36 @@
-var TRACEUR_OUTPUT_DIR = 'traceur-output',
-  gulp = require('gulp'),
+function getInputDirectory(argv) {
+  if (argv.input) {
+    return argv.input;
+  }
+  return '.';
+}
+
+function getOutputDirectory(argv) {
+  if (argv.output) {
+    return argv.output;
+  }
+  return 'traceur-output';
+}
+
+var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
   traceur = require('gulp-traceur'),
-  clean = require('gulp-clean');
+  del = require('del'),
+  argv  = require('yargs').argv,
+  inputDir = getInputDirectory(argv),
+  outputDir = getOutputDirectory(argv);
+
+// Gulp tasks definition
 
 gulp.task('default', [ 'test' ]);
  
 gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
-  return gulp.src([ TRACEUR_OUTPUT_DIR + '/*_test.spec.js' ])
+  return gulp.src([ outputDir + '/*_test.spec.js' ])
     .pipe(jasmine());
 });
 
 gulp.task('traceur', function () {
-  return gulp.src([ '*.js', '!gulpfile.js', '!example.js' ])
+  return gulp.src([ inputDir + '/*.js' ])
     .pipe(traceur({
       modules: 'commonjs',
 
@@ -31,16 +49,15 @@ gulp.task('traceur', function () {
       require: true,
       types: true
     }))
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
 gulp.task('copy-runtime', function () {
   return gulp.src(traceur.RUNTIME_PATH)
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
-gulp.task('clean', function () {
-  return gulp.src(TRACEUR_OUTPUT_DIR, { read: false })
-    .pipe(clean());
+gulp.task('clean', function (cb) {
+  del([ outputDir ], cb);
 });
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
     "gulp-traceur": "~0.17.1",
-    "gulp-clean": "~0.3.1",
+    "del": "~1.2.0",
     "yargs": "~3.15.0"
   },
   "dependencies": {},
@@ -22,4 +22,3 @@
     "MIT"
   ]
 }
-

--- a/palindrome-products/gulpfile.js
+++ b/palindrome-products/gulpfile.js
@@ -1,18 +1,36 @@
-var TRACEUR_OUTPUT_DIR = 'traceur-output',
-  gulp = require('gulp'),
+function getInputDirectory(argv) {
+  if (argv.input) {
+    return argv.input;
+  }
+  return '.';
+}
+
+function getOutputDirectory(argv) {
+  if (argv.output) {
+    return argv.output;
+  }
+  return 'traceur-output';
+}
+
+var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
   traceur = require('gulp-traceur'),
-  clean = require('gulp-clean');
+  del = require('del'),
+  argv  = require('yargs').argv,
+  inputDir = getInputDirectory(argv),
+  outputDir = getOutputDirectory(argv);
+
+// Gulp tasks definition
 
 gulp.task('default', [ 'test' ]);
  
 gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
-  return gulp.src([ TRACEUR_OUTPUT_DIR + '/*_test.spec.js' ])
+  return gulp.src([ outputDir + '/*_test.spec.js' ])
     .pipe(jasmine());
 });
 
 gulp.task('traceur', function () {
-  return gulp.src([ '*.js', '!gulpfile.js', '!example.js' ])
+  return gulp.src([ inputDir + '/*.js' ])
     .pipe(traceur({
       modules: 'commonjs',
 
@@ -31,16 +49,15 @@ gulp.task('traceur', function () {
       require: true,
       types: true
     }))
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
 gulp.task('copy-runtime', function () {
   return gulp.src(traceur.RUNTIME_PATH)
-    .pipe(gulp.dest(TRACEUR_OUTPUT_DIR));
+    .pipe(gulp.dest(outputDir));
 });
 
-gulp.task('clean', function () {
-  return gulp.src(TRACEUR_OUTPUT_DIR, { read: false })
-    .pipe(clean());
+gulp.task('clean', function (cb) {
+  del([ outputDir ], cb);
 });
 


### PR DESCRIPTION
This PR includes the following improvements:

1. Replace deprecated dev dependency, `gulp-clean` with `del`
2. Decide whether input and output dirs come from command line arguments or harcoded values. Hardcoded values will be used in individual assignments.
3. `make` command creates copies of `gulpfile.js` in each assignment. This way, it is as if there were no `gulpfile.js` duplication. Any change in ./gulpfile.js will be copied to each `<assignment>/gulpfile.js` so that all `gulpfile.js`s will be synchronized.