### PR TITLE
Make anagram example simple and more ES2015-ish

### DIFF
--- a/anagram/example.js
+++ b/anagram/example.js
@@ -12,8 +12,8 @@ export default class Anagram {
     this.word = word;
   }
 
-  matches(...words) {
-    words = Array.isArray(words[0]) ? words[0] : words;
+  matches(words) {
+    words = Array.isArray(words) ? words : Array.from(arguments);
 
     return words.filter(candidate => {
       return !sameWord(this.word, candidate) && isAnagram(this.word, candidate);


### PR DESCRIPTION
Previously, the ES2015 feature used was the spread operator `...` as `matches` method params. But it made the code use `words[0]` to do some checks, and it looked ugly.

Stop using the spread operator and use the new method [`Array.from()`][1] makes the code cleaner and easier to read.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from