### PR TITLE
Replace Traceur with Babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ node_modules
 .idea
 
 */node_modules
-*/traceur-output
+*/babel-output

--- a/anagram/gulpfile.js
+++ b/anagram/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/anagram/package.json
+++ b/anagram/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "babel": "~5.8.29",
+    "gulp-babel": "~5.3.0"
   }
 }

--- a/beer-song/gulpfile.js
+++ b/beer-song/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/beer-song/package.json
+++ b/beer-song/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/bob/gulpfile.js
+++ b/bob/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/bob/package.json
+++ b/bob/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "del": "~2.0.2",
-    "yargs": "~3.27.0"
+    "yargs": "~3.27.0",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/etl/gulpfile.js
+++ b/etl/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/etl/package.json
+++ b/etl/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/food-chain/gulpfile.js
+++ b/food-chain/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/food-chain/package.json
+++ b/food-chain/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/gigasecond/gulpfile.js
+++ b/gigasecond/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/gigasecond/package.json
+++ b/gigasecond/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "babel": "~5.8.29",
+    "gulp-babel": "~5.3.0"
   }
 }

--- a/grade-school/gulpfile.js
+++ b/grade-school/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/grade-school/package.json
+++ b/grade-school/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "babel": "~5.8.29",
+    "gulp-babel": "~5.3.0"
   }
 }

--- a/grains/gulpfile.js
+++ b/grains/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/grains/package.json
+++ b/grains/package.json
@@ -9,13 +9,12 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "traceur": "0.0.90",
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
     "del": "~2.0.2",
     "yargs": "~3.27.0",
-    "big-integer": "~1.6.3"
+    "babel": "~5.8.29",
+    "gulp-babel": "~5.3.0"
   },
   "dependencies": {},
   "scripts": {},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/hamming/gulpfile.js
+++ b/hamming/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/hamming/package.json
+++ b/hamming/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/hello-world/gulpfile.js
+++ b/hello-world/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "del": "~2.0.2",
-    "yargs": "~3.27.0"
+    "yargs": "~3.27.0",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/leap/gulpfile.js
+++ b/leap/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/leap/package.json
+++ b/leap/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "traceur": "0.0.90",
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
     "del": "~2.0.2",
-    "yargs": "~3.27.0"
+    "yargs": "~3.27.0",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   },
   "dependencies": {},
   "scripts": {},

--- a/palindrome-products/gulpfile.js
+++ b/palindrome-products/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/palindrome-products/package.json
+++ b/palindrome-products/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/phone-number/gulpfile.js
+++ b/phone-number/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/phone-number/package.json
+++ b/phone-number/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/rna-transcription/gulpfile.js
+++ b/rna-transcription/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/rna-transcription/package.json
+++ b/rna-transcription/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }

--- a/robot-name/gulpfile.js
+++ b/robot-name/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/robot-name/package.json
+++ b/robot-name/package.json
@@ -9,12 +9,12 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "traceur": "0.0.90",
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
     "del": "~2.0.2",
-    "yargs": "~3.27.0"
+    "yargs": "~3.27.0",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   },
   "dependencies": {},
   "scripts": {},

--- a/space-age/gulpfile.js
+++ b/space-age/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/space-age/package.json
+++ b/space-age/package.json
@@ -9,12 +9,12 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "traceur": "0.0.90",
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
     "del": "~2.0.2",
-    "yargs": "~3.27.0"
+    "yargs": "~3.27.0",
+    "babel": "~5.8.29",
+    "gulp-babel": "~5.3.0"
   },
   "dependencies": {},
   "scripts": {},
@@ -22,4 +22,3 @@
     "MIT"
   ]
 }
-

--- a/word-count/gulpfile.js
+++ b/word-count/gulpfile.js
@@ -14,7 +14,8 @@ function getOutputDirectory(argv) {
 
 var gulp = require('gulp'),
   jasmine = require('gulp-jasmine'),
-  traceur = require('gulp-traceur'),
+  babel = require('gulp-babel'),
+  polyfill = require('babel/polyfill'),
   del = require('del'),
   argv  = require('yargs').argv,
   inputDir = getInputDirectory(argv),
@@ -24,36 +25,14 @@ var gulp = require('gulp'),
 
 gulp.task('default', [ 'test' ]);
 
-gulp.task('test', [ 'traceur', 'copy-runtime' ], function () {
+gulp.task('test', [ 'babel' ], function () {
   return gulp.src([ outputDir + '/*.spec.js' ])
     .pipe(jasmine());
 });
 
-gulp.task('traceur', function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
-    .pipe(traceur({
-      modules: 'commonjs',
-
-      // experimental options
-      properTailCalls: true,
-      symbols: true,
-      annotations: true,
-      arrayComprehension: true,
-      asyncFunctions: true,
-      asyncGenerators: true,
-      exponentiation: true,
-      exportFromExtended: true,
-      forOn: true,
-      generatorComprehension: true,
-      memberVariables: true,
-      require: true,
-      types: true
-    }))
-    .pipe(gulp.dest(outputDir));
-});
-
-gulp.task('copy-runtime', function () {
-  return gulp.src(traceur.RUNTIME_PATH)
+    .pipe(babel())
     .pipe(gulp.dest(outputDir));
 });
 

--- a/word-count/package.json
+++ b/word-count/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "gulp": "~3.9.0",
     "gulp-jasmine": "~2.0.1",
-    "gulp-traceur": "~0.17.1",
-    "traceur": "0.0.90",
     "gulp-clean": "~0.3.1",
     "yargs": "~3.27.0",
-    "del": "~2.0.2"
+    "del": "~2.0.2",
+    "gulp-babel": "~5.3.0",
+    "babel": "~5.8.29"
   }
 }


### PR DESCRIPTION
Stop using Traceur to transpile ECMAScript 2015 code into ES5
and start using Babel. Babel has implemented more ES2015
features than any other project, even browsers.

`gulpfile.js` and `package.json` files of each exercise has changed because when users fetch an exercise in exercism.io they need the Babel dependencies and they need new Gulp tasks to use Babel instead of Traceur to transpile code.

Fixes #51