### PR TITLE
test to ensure roster object is private

### DIFF
--- a/grade-school/grade-school.spec.js
+++ b/grade-school/grade-school.spec.js
@@ -62,4 +62,12 @@ describe('School', () => {
     expect(school.roster()).toEqual(expectedSortedStudents);
   });
 
+  xit('roster cannot be modified outside of module', () => {
+    school.add('Aimee', 2);
+    const roster = school.roster();
+    roster[3]=['Oops.'];
+    const expectedDb = { 2 : [ 'Aimee' ] };
+    expect(school.roster()).toEqual(expectedDb);
+  });
+
 });


### PR DESCRIPTION
@rchavarria this is a test to ensure the ```roster``` object can't be modified from the outside.

Not sure if this is present in other tracks or if you want to merge, but here it is if you want it.