### PR TITLE
Remove bigint

### DIFF
--- a/grains/grains.spec.js
+++ b/grains/grains.spec.js
@@ -27,7 +27,6 @@
  * See its tests in this folder for a quick primer on how to use it! ( :
  */
 
-import BigInt from './big-integer';
 import Grains from './grains';
 
 describe('Grains', () => {


### PR DESCRIPTION
BigInt does not need to be imported to grains.spec.js