### PR TITLE
Provide a pattern to identify a file as a test file based on its name

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "language": "ECMAScript",
   "repository": "https://github.com/exercism/xecmascript",
   "active": true,
+  "test_pattern": ".*[.]spec[.]js$",
   "problems": [
     "hello-world",
     "leap",


### PR DESCRIPTION
A test pattern can be defined in `config.json` to help exercism.io to identify files that contain tests.

That would avoid having small bugs as described on [exercism/exercism.io#2610](https://github.com/exercism/exercism.io/issues/2610).