### PR TITLE
Use NodeJS language instead of bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-language: bash
+language: node_js
+
+node_js:
+  - "4.1"
+
+sudo: false
 
 script:
   - bin/fetch-configlet


### PR DESCRIPTION
This PR tries to fix Travis CI builds that fail in the new Travis CI platform.

Now, instead of configuring `bash` as the build language (in the `.travis.yaml` file), `node_js` is configured. The used version for NodeJS is 4.1.

I've tried in my fork of this project and it works in the old Travis CI platform. This PR will check if the new configuration works for this repository.