### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
+---
 language: node_js
-
 node_js:
-  - "4.1"
-
+- '4.1'
 sudo: false
-
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
-  - make test
+- bin/fetch-configlet
+- bin/configlet .
+- make test


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.