### PR TITLE
Do not force users to lint their code when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-assignment: node_modules
 	@cp grains/big-integer.$(FILEEXT) $(OUTDIR)
 	@sed 's/xit/it/g' $(ASSIGNMENT)/$(TSTFILE) > $(INTDIR)/$(TSTFILE)
 	@cp $(ASSIGNMENT)/$(EXAMPLE) $(INTDIR)/$(ASSIGNMENT).$(FILEEXT)
-	@gulp test --input $(INTDIR) --output $(OUTDIR)
+	@gulp lint test --input $(INTDIR) --output $(OUTDIR)
 
 test:
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done

--- a/accumulate/gulpfile.js
+++ b/accumulate/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/allergies/gulpfile.js
+++ b/allergies/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/anagram/gulpfile.js
+++ b/anagram/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/atbash-cipher/gulpfile.js
+++ b/atbash-cipher/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/beer-song/gulpfile.js
+++ b/beer-song/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/binary-search-tree/gulpfile.js
+++ b/binary-search-tree/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/binary-search/gulpfile.js
+++ b/binary-search/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/binary/gulpfile.js
+++ b/binary/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/bob/gulpfile.js
+++ b/bob/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/bracket-push/gulpfile.js
+++ b/bracket-push/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/circular-buffer/gulpfile.js
+++ b/circular-buffer/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/clock/gulpfile.js
+++ b/clock/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/crypto-square/gulpfile.js
+++ b/crypto-square/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/custom-set/gulpfile.js
+++ b/custom-set/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/difference-of-squares/gulpfile.js
+++ b/difference-of-squares/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -39,6 +39,8 @@ Each assignment needs some tools to run the tests:
 * [Jasmine](http://jasmine.github.io): to run tests
 * [Gulp](http://gulpjs.com): to automate everything, you don't need to worry
 about anything
+* [ESLint](http://eslint.org/) (optional): to perform several static analysis and
+coding style checks to your ECMAScript code.
 
 They can be installed running this command within each assignment directory:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -4,6 +4,20 @@ Execute the tests with:
 $ gulp test
 ```
 
+Be sure your code follows best practices and coding styles, as other users do, with
+ESLint, a tool to perform static analysis to your code. Sometimes, tools like this
+save you some time detecting typos or silly mistakes in your ECMAScript code:
+
+```bash
+$ gulp lint
+```
+
+Or do both at the same time:
+
+```bash
+$ gulp lint test
+```
+
 ## Making Your First ECMAScript 2015 Module
 
 Usually, tests on this track will load your implementation importing it as a

--- a/etl/gulpfile.js
+++ b/etl/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/food-chain/gulpfile.js
+++ b/food-chain/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/gigasecond/gulpfile.js
+++ b/gigasecond/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/grade-school/gulpfile.js
+++ b/grade-school/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/grains/gulpfile.js
+++ b/grains/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/hamming/gulpfile.js
+++ b/hamming/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/hello-world/gulpfile.js
+++ b/hello-world/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/hexadecimal/gulpfile.js
+++ b/hexadecimal/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/kindergarten-garden/gulpfile.js
+++ b/kindergarten-garden/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/largest-series-product/gulpfile.js
+++ b/largest-series-product/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/leap/gulpfile.js
+++ b/leap/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/linked-list/gulpfile.js
+++ b/linked-list/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/luhn/gulpfile.js
+++ b/luhn/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/matrix/gulpfile.js
+++ b/matrix/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/meetup/gulpfile.js
+++ b/meetup/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/nth-prime/gulpfile.js
+++ b/nth-prime/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/ocr-numbers/gulpfile.js
+++ b/ocr-numbers/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/octal/gulpfile.js
+++ b/octal/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/palindrome-products/gulpfile.js
+++ b/palindrome-products/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/pangram/gulpfile.js
+++ b/pangram/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/pascals-triangle/gulpfile.js
+++ b/pascals-triangle/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/phone-number/gulpfile.js
+++ b/phone-number/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/pig-latin/gulpfile.js
+++ b/pig-latin/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/prime-factors/gulpfile.js
+++ b/prime-factors/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/pythagorean-triplet/gulpfile.js
+++ b/pythagorean-triplet/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/queen-attack/gulpfile.js
+++ b/queen-attack/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/raindrops/gulpfile.js
+++ b/raindrops/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/rna-transcription/gulpfile.js
+++ b/rna-transcription/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/robot-name/gulpfile.js
+++ b/robot-name/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/robot-simulator/gulpfile.js
+++ b/robot-simulator/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/roman-numerals/gulpfile.js
+++ b/roman-numerals/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/saddle-points/gulpfile.js
+++ b/saddle-points/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/say/gulpfile.js
+++ b/say/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/scrabble-score/gulpfile.js
+++ b/scrabble-score/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/secret-handshake/gulpfile.js
+++ b/secret-handshake/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/series/gulpfile.js
+++ b/series/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/sieve/gulpfile.js
+++ b/sieve/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/simple-cipher/gulpfile.js
+++ b/simple-cipher/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/space-age/gulpfile.js
+++ b/space-age/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/strain/gulpfile.js
+++ b/strain/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/sum-of-multiples/gulpfile.js
+++ b/sum-of-multiples/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/triangle/gulpfile.js
+++ b/triangle/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/trinary/gulpfile.js
+++ b/trinary/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/two-bucket/gulpfile.js
+++ b/two-bucket/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/word-count/gulpfile.js
+++ b/word-count/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));

--- a/wordy/gulpfile.js
+++ b/wordy/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('test', [ 'babel' ], function () {
     .pipe(jasmine());
 });
 
-gulp.task('babel', [ 'lint' ], function () {
+gulp.task('babel', function () {
   return gulp.src([ inputDir + '/*.js' ])
     .pipe(babel())
     .pipe(gulp.dest(outputDir));


### PR DESCRIPTION
As discussed on #179, this PR separates `lint` and `test` tasks to let users to run them separately.

This will avoid having errors not related to tests that can be frustrating for beginners. 

This PR is completed with PR [docs#179](https://github.com/exercism/docs/pull/179), that modifies the `README` file of the track to explain this change.