### PR TITLE
Remove test which pops empty list

### DIFF
--- a/exercises/linked-list/linked-list.spec.js
+++ b/exercises/linked-list/linked-list.spec.js
@@ -42,10 +42,6 @@ describe('LinkedList', () => {
     expect(list.pop()).toBe(50);
     expect(list.shift()).toBe(30);
   });
-  xit('pops undefined when there are no elements', () => {
-    const list = new LinkedList();
-    expect(list.pop()).toBe(undefined);
-  });
   xit('can count its elements', () => {
     const list = new LinkedList();
     expect(list.count()).toBe(0);


### PR DESCRIPTION
As observed by @cebial on the [JS track](https://github.com/exercism/xjavascript/pull/167), there is a test against an empty list that is specifically prohibited by the README for this exercise.

This PR removes that test.