### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/exercises/largest-series-product/largest-series-product.spec.js
+++ b/exercises/largest-series-product/largest-series-product.spec.js
@@ -2,29 +2,7 @@ import Series from './largest-series-product';
 
 describe('Series', () => {
 
-  it('digits', () => {
-    expect(new Series('0123456789').digits).toEqual([0,1,2,3,4,5,6,7,8,9]);
-  });
-
-  xit('maintains digit order', () => {
-    expect(new Series('9876543210').digits).toEqual([9,8,7,6,5,4,3,2,1,0]);
-  });
-
-  xit('returns empty array for no digits', () => {
-    expect(new Series('').digits).toEqual([]);
-  });
-
-  xit('slices by 2', () => {
-    expect(new Series('01234').slices(2))
-      .toEqual([[0, 1], [1, 2], [2, 3], [3, 4]]);
-  });
-
-  xit('slices by 3', () => {
-    expect(new Series('982347').slices(3))
-      .toEqual([[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]]);
-  });
-
-  xit('can get the largest product of 2', () => {
+  it('can get the largest product of 2', () => {
     expect(new Series('0123456789').largestProduct(2)).toBe(72);
   });
 


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (already implemented by this track).

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192

Relevant to #202: This will satisfy the first part of the issue (ensure
the track does not test implementation details); the question of whether
hints are necessary is uncertain (as it is not known whether students
will consider this problem too hard without guidance).