### PR TITLE
Update tests and example to be case-agnostic

### DIFF
--- a/exercises/word-count/example.js
+++ b/exercises/word-count/example.js
@@ -5,7 +5,8 @@ class Words {
     let words = input.match(/\S+/g);
 
     words.forEach((word) => {
-      counts[word] = counts.hasOwnProperty(word) ? counts[word] + 1 : 1;
+      const lcWord = word.toLowerCase();
+      counts[lcWord] = counts.hasOwnProperty(lcWord) ? counts[lcWord] + 1 : 1;
     });
 
     return counts;

--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -28,7 +28,7 @@ describe('words()', () => {
     expect(words.count('testing 1 2 testing')).toEqual(expectedCounts);
   });
 
-  xit('respects case', () => {
+  xit('normalizes to lower case', () => {
     const expectedCounts = { go: 3 };
     expect(words.count('go Go GO')).toEqual(expectedCounts);
   });

--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -29,12 +29,12 @@ describe('words()', () => {
   });
 
   xit('respects case', () => {
-    const expectedCounts = { go: 1, Go:1, GO:1 };
+    const expectedCounts = { go: 3 };
     expect(words.count('go Go GO')).toEqual(expectedCounts);
   });
 
   xit('counts properly international characters', () => {
-    const expectedCounts = { '¡Hola!': 1, '¿Qué': 1, 'tal?': 1, 'Привет!': 1 };
+    const expectedCounts = { '¡hola!': 1, '¿qué': 1, 'tal?': 1, 'привет!': 1 };
     expect(words.count('¡Hola! ¿Qué tal? Привет!')).toEqual(expectedCounts);
   });
 
@@ -54,12 +54,12 @@ describe('words()', () => {
   });
 
   xit('does not count leading or trailing whitespace', () => {
-    const expectedCounts = { Introductory: 1, Course: 1 };
+    const expectedCounts = { introductory: 1, course: 1 };
     expect(words.count('\t\tIntroductory Course      ')).toEqual(expectedCounts);
   });
 
   xit('handles properties that exist on Object’s prototype', () => {
-    const expectedCounts = { reserved: 1, words : 1, like :1,  prototype: 1, and : 1, toString: 1,  'ok?': 1};
+    const expectedCounts = { reserved: 1, words : 1, like :1,  prototype: 1, and : 1, tostring: 1,  'ok?': 1};
     expect(words.count('reserved words like prototype and toString ok?')).toEqual(expectedCounts);
   });
 


### PR DESCRIPTION
The test metadata for this exercise specifies that counts should be independent of the case of the input words.

This PR brings this exercise in to conformance with that requirement.