### PR TITLE
Binary: add missing test

### DIFF
--- a/exercises/binary/binary.spec.js
+++ b/exercises/binary/binary.spec.js
@@ -24,6 +24,7 @@ describe('binary', () => {
     expect(new Binary('012').toDecimal()).toEqual(0);
     expect(new Binary('10nope').toDecimal()).toEqual(0);
     expect(new Binary('nope10').toDecimal()).toEqual(0);
+    expect(new Binary('10nope10').toDecimal()).toEqual(0);
   });
 
 });


### PR DESCRIPTION
Addresses #213 and adds the missing test: alphabetic characters in the number makes it to be decimal 0.