### PR TITLE
Wrap the function to test

### DIFF
--- a/exercises/circular-buffer/circular-buffer.spec.js
+++ b/exercises/circular-buffer/circular-buffer.spec.js
@@ -7,14 +7,14 @@ describe('CircularBuffer', () => {
 
   it('reading an empty buffer throws a BufferEmptyException', () => {
     const buffer = circularBuffer(1);
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
   xit('write and read back one item', () => {
     const buffer = circularBuffer(1);
     buffer.write('1');
     expect(buffer.read()).toBe('1');
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
   xit('write and read back multiple items', () => {
@@ -23,7 +23,7 @@ describe('CircularBuffer', () => {
     buffer.write('2');
     expect(buffer.read()).toBe('1');
     expect(buffer.read()).toBe('2');
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
   xit('clearing a buffer', () => {
@@ -31,7 +31,7 @@ describe('CircularBuffer', () => {
     buffer.write('1');
     buffer.write('2');
     buffer.clear();
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
     buffer.write('3');
     buffer.write('4');
     expect(buffer.read()).toBe('3');
@@ -78,7 +78,7 @@ describe('CircularBuffer', () => {
     buffer.forceWrite('A');
     expect(buffer.read()).toBe('2');
     expect(buffer.read()).toBe('A');
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
   xit('forced writes act like write in a non-full buffer', () => {
@@ -87,7 +87,7 @@ describe('CircularBuffer', () => {
     buffer.forceWrite('2');
     expect(buffer.read()).toBe('1');
     expect(buffer.read()).toBe('2');
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
   xit('alternate force write and read into full buffer', () => {
@@ -105,7 +105,7 @@ describe('CircularBuffer', () => {
     expect(buffer.read()).toBe('8');
     expect(buffer.read()).toBe('A');
     expect(buffer.read()).toBe('B');
-    expect(buffer.read).toThrow(bufferEmptyException());
+    expect(()=>buffer.read()).toThrow(bufferEmptyException());
   });
 
 });


### PR DESCRIPTION
... such that if `buffer` is an object, `this` is set to the proper value when `read` is invoked.