### PR TITLE
Trinary misses an illegal case

### DIFF
--- a/exercises/trinary/example.js
+++ b/exercises/trinary/example.js
@@ -7,8 +7,17 @@ export default class Trinary {
   }
 
   toDecimal () {
-    const decimal = this.digits.reduce(this.accumulator, 0);
-    return isNaN(decimal) ? 0 : decimal;
+    if (this.someDigitIsInvalid()) {
+      return 0;
+    }
+
+    return this.digits.reduce(this.accumulator, 0);
+  }
+
+  someDigitIsInvalid() {
+    const greaterThanBase = this.digits.some(d => d >= BASE);
+    const notANumber = this.digits.some(d => isNaN(d));
+    return greaterThanBase || notANumber;
   }
 
   accumulator (decimal, digit, index) {

--- a/exercises/trinary/trinary.spec.js
+++ b/exercises/trinary/trinary.spec.js
@@ -38,4 +38,8 @@ describe('Trinary', () => {
     expect(0).toEqual(new Trinary('carrot').toDecimal());
   });
 
+  xit('digits from 3 to 9 are invalid', () => {
+    expect(0).toEqual(new Trinary('123').toDecimal());
+  });
+
 });


### PR DESCRIPTION
Trinary numbers should contain only digits from `0` to `2`

Trinary numbers have a base of `3`, and they can only be
expressed with digits from `0` to `n < BASE`