### PR TITLE
Simple cipher misses an illegal case.

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -4,7 +4,7 @@ describe('Random key cipher',  () => {
   const cipher = new Cipher();
 
   it('has a key made of letters', () => {
-    expect(cipher.key).toMatch(/[a-z]+/);
+    expect(cipher.key).toMatch(/^[a-z]+$/);
   });
 
   // Here we take advantage of the fact that plaintext of "aaa..."


### PR DESCRIPTION
It was pass string like '123ABCxyz'.