### PR TITLE
Add test to Grade School

### DIFF
--- a/exercises/grade-school/grade-school.spec.js
+++ b/exercises/grade-school/grade-school.spec.js
@@ -70,4 +70,11 @@ describe('School', () => {
     expect(school.roster()).toEqual(expectedDb);
   });
 
+  xit('roster cannot be modified outside of module using grade()', () => {
+    school.add('Aimee', 2);
+    school.grade(2).push('Oops.');
+    const expectedDb = { 2 : [ 'Aimee' ] };
+    expect(school.roster()).toEqual(expectedDb);
+  });
+
 });


### PR DESCRIPTION
Grade School has a test to prevent modifications when calling the roster() method. However, there is no test to prevent modifications when calling the grade() method. This PR adds a test to address the grade() scenario.

My code in this submission passes the existing tests, but allows modifications through grade():
http://exercism.io/submissions/971cbf70d109466ba098fa6c0195eb00