### PR TITLE
Update setup to not install `gulp` globally

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -7,16 +7,6 @@ http://exercism.io/languages/ecmascript
 
 ## Requirements
 
-They are already described in the link above, but just as a
-quick reference:
-
-Install globally a tool to run [Gulp](http://gulpjs.com) if
-it is not installed yet:
-
-```bash
-$ npm install -g gulp-cli
-```
-
 Install assignment dependencies:
 
 ```bash
@@ -28,7 +18,7 @@ $ npm install
 Execute the tests with:
 
 ```bash
-$ gulp test
+$ npm test
 ```
 
 In many test suites all but the first test have been skipped.

--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -1,4 +1,3 @@
-{
   "name": "xecmascript",
   "version": "0.0.0",
   "description": "Exercism exercises in ECMAScript 6.",
@@ -18,7 +17,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/hexadecimal/package.json
+++ b/exercises/hexadecimal/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/linked-list/package.json
+++ b/exercises/linked-list/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/octal/package.json
+++ b/exercises/octal/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/robot-name/package.json
+++ b/exercises/robot-name/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "yargs": "~3.27.0"
   },
   "scripts": {
-    "test": "gulp lint test"
+    "test": "gulp test",
+    "lint-test": "gulp lint test"
   },
   "licenses": [
     "MIT"


### PR DESCRIPTION
`gulp` doesn't need to be installed globally because it's set up as an `npm` script in `package.json` for all of the exercises. However, the documentation currently instructs people to install it globally and then run tests directly using `gulp` instead of `npm test`.

Closes #246
Closes #247