### PR TITLE
Rna-Transcription: Handle invalid nucleotides in strand

### DIFF
--- a/exercises/rna-transcription/example.js
+++ b/exercises/rna-transcription/example.js
@@ -7,7 +7,14 @@ const DNA_TO_RNA = {
 
 export default class Transcriptor {
   toRna(dna) {
-    return dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide]);
+    let rna = dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide])
+
+    if (rna.length !== dna.length) {
+      // invalid characters in the strand
+      throw new Error('Invalid input DNA.');
+    }
+    else {
+      return rna;
+    }
   }
 }
-

--- a/exercises/rna-transcription/rna-transcription.spec.js
+++ b/exercises/rna-transcription/rna-transcription.spec.js
@@ -24,4 +24,22 @@ describe('Transcriptor', () => {
         .toEqual('UGCACCAGAAUU');
   });
 
+  xit('correctly handles invalid input', () => {
+    expect(() => transcriptor.toRna('U')).toThrow(
+      new Error('Invalid input DNA.')
+    );
+  });
+
+  xit('correctly handles completely invalid input', () => {
+    expect(() => transcriptor.toRna('XXX')).toThrow(
+      new Error('Invalid input DNA.')
+    );
+  });
+
+  xit('correctly handles partially invalid input', () => {
+    expect(() => transcriptor.toRna('ACGTXXXCTTAA')).toThrow(
+      new Error('Invalid input DNA.')
+    );
+  });
+
 });


### PR DESCRIPTION
As per [x-common canonical data](https://github.com/exercism/x-common/blob/master/exercises/rna-transcription/canonical-data.json#L40-L54)

Fixes #248