### PR TITLE
Make phone-number specs consistent with x-common data

### DIFF
--- a/exercises/phone-number/example.js
+++ b/exercises/phone-number/example.js
@@ -2,40 +2,27 @@ export default class PhoneNumber {
 
   constructor(number) {
     this.rawNumber = number;
-    this.cleanedNumber = cleanNumber(number);
   }
 
-  number() { return this.cleanedNumber; }
+  number() {
+    if(/[a-zA-Z]/.test(this.rawNumber)) {
+      return null;
+    }
 
-  areaCode() { return this.cleanedNumber.substr(0, 3); }
-
-  toString() {
-    return '(' + this.areaCode() + ')' +
-           ' ' +
-           exchangeCode(this.cleanedNumber) + '-' +
-           subscriberNumber(this.cleanedNumber);
-  }
-}
-
-function cleanNumber(number) {
-  const num = number.replace(/\D/g,'');
-
-  if (num.length === 10) {
-    return num;
+    return this._cleanedNumber();
   }
 
-  if (num.length === 11 && num[0] === '1') {
-    return num.substr(1);
+  _cleanedNumber() {
+    let num = this.rawNumber.replace(/\D/g,'');
+
+    if (num.length === 10) {
+      return num;
+    }
+
+    if (num.length === 11 && num[0] === '1') {
+      return num.substr(1);
+    }
+
+    return null;
   }
-
-  return '0000000000';
 }
-
-function exchangeCode(number) {
-  return number.substr(3, 3);
-}
-
-function subscriberNumber(number) {
-  return number.substr(6);
-}
-

--- a/exercises/phone-number/phone-number.spec.js
+++ b/exercises/phone-number/phone-number.spec.js
@@ -2,7 +2,7 @@ import PhoneNumber from './phone-number';
 
 describe('PhoneNumber()', () => {
 
-  it('cleans the number (123) 456-7890', () => {
+  it('cleans the number', () => {
     const phone = new PhoneNumber('(123) 456-7890');
     expect(phone.number()).toEqual('1234567890');
   });
@@ -12,29 +12,44 @@ describe('PhoneNumber()', () => {
     expect(phone.number()).toEqual('1234567890');
   });
 
-  xit('valid when 11 digits and first digit is 1', () => {
-    const phone = new PhoneNumber('11234567890');
+  xit('cleans numbers with multiple spaces', () => {
+    const phone = new PhoneNumber('123 456   7890   ');
     expect(phone.number()).toEqual('1234567890');
-  });
-
-  xit('invalid when 11 digits', () => {
-    const phone = new PhoneNumber('21234567890');
-    expect(phone.number()).toEqual('0000000000');
   });
 
   xit('invalid when 9 digits', () => {
     const phone = new PhoneNumber('123456789');
-    expect(phone.number()).toEqual('0000000000');
+    expect(phone.number()).toEqual(null);
   });
 
-  xit('has an area code', () => {
-    const phone = new PhoneNumber('1234567890');
-    expect(phone.areaCode()).toEqual('123');
+  xit('invalid when 11 digits', () => {
+    const phone = new PhoneNumber('21234567890');
+    expect(phone.number()).toEqual(null);
   });
 
-  xit('formats a number', () => {
-    const phone = new PhoneNumber('1234567890');
-    expect(phone.toString()).toEqual('(123) 456-7890');
+  xit('valid when 11 digits and starting with 1', () => {
+    const phone = new PhoneNumber('11234567890');
+    expect(phone.number()).toEqual('1234567890');
+  });
+
+  xit('invalid when 12 digits', () => {
+    const phone = new PhoneNumber('321234567890');
+    expect(phone.number()).toEqual(null);
+  });
+
+  xit('invalid with letters', () => {
+    const phone = new PhoneNumber('123-abc-7890');
+    expect(phone.number()).toEqual(null);
+  });
+
+  xit('invalid with punctuations', () => {
+    const phone = new PhoneNumber('123-@:!-7890');
+    expect(phone.number()).toEqual(null);
+  });
+
+  xit('invalid with right number of digits but letters mixed in', () => {
+    const phone = new PhoneNumber('1a2b3c4d5e6f7g8h9i0j');
+    expect(phone.number()).toEqual(null);
   });
 
 });


### PR DESCRIPTION
Recently x-common got data for phone-numbers:
https://github.com/exercism/x-common/blob/master/exercises/phone-number/canonical-data.json

Make our tests consistent with that data.