### PR TITLE
Make hello-world more simple

### DIFF
--- a/exercises/hello-world/example.js
+++ b/exercises/hello-world/example.js
@@ -1,9 +1,6 @@
 
-class HelloWorld {
-    hello(name = 'World') {
-        return `Hello, ${name}!`;
-    }
+const helloWorld = () => {
+  return 'Hello, World!';
 }
 
-export default HelloWorld;
-
+export default helloWorld;

--- a/exercises/hello-world/hello-world.js
+++ b/exercises/hello-world/hello-world.js
@@ -3,13 +3,10 @@
 // convenience to get you started writing code faster.
 //
 
-class HelloWorld {
-  hello() {
-    //
-    // YOUR CODE GOES HERE
-    //
-  }
+const helloWorld = () => {
+  //
+  // YOUR CODE GOES HERE
+  //
 }
 
-export default HelloWorld;
-
+export default helloWorld;

--- a/exercises/hello-world/hello-world.spec.js
+++ b/exercises/hello-world/hello-world.spec.js
@@ -1,18 +1,7 @@
-import HelloWorld from './hello-world';
+import helloWorld from './hello-world';
 
 describe('Hello World', () => {
-  const helloWorld = new HelloWorld();
-
-  it('says hello world with no name', () => {
-    expect(helloWorld.hello()).toEqual('Hello, World!');
-  });
-
-  xit('says hello to bob', () => {
-    expect(helloWorld.hello('Bob')).toEqual('Hello, Bob!');
-  });
-
-  xit('says hello to sally', () => {
-    expect(helloWorld.hello('Sally')).toEqual('Hello, Sally!');
+  it('says hello', () => {
+    expect(helloWorld()).toEqual('Hello, World!');
   });
 });
-


### PR DESCRIPTION
by always expecting "Hello, World!"

Change in x-common: [here](https://github.com/exercism/x-common/pull/544)

Upcoming new exercise to kinda replace `hello-world`: [here](https://github.com/exercism/x-common/pull/759)

Since this `hello-world` is just meant to be a sanity check for everything working, I also went ahead and removed the use of class for the sake of simplicity.
We can introduce classes with the next `two-fer` exercise.