### PR TITLE
Maintain class consistency

### DIFF
--- a/exercises/hello-world/example.js
+++ b/exercises/hello-world/example.js
@@ -1,6 +1,7 @@
-
-const helloWorld = () => {
-  return 'Hello, World!';
+class HelloWorld {
+  hello() {
+    return "Hello, World!";
+  }
 }
 
-export default helloWorld;
+export default HelloWorld;

--- a/exercises/hello-world/hello-world.js
+++ b/exercises/hello-world/hello-world.js
@@ -3,10 +3,12 @@
 // convenience to get you started writing code faster.
 //
 
-const helloWorld = () => {
-  //
-  // YOUR CODE GOES HERE
-  //
+class HelloWorld {
+  hello() {
+    //
+    // YOUR CODE GOES HERE
+    //
+  }
 }
 
-export default helloWorld;
+export default HelloWorld;

--- a/exercises/hello-world/hello-world.spec.js
+++ b/exercises/hello-world/hello-world.spec.js
@@ -1,7 +1,9 @@
-import helloWorld from './hello-world';
+import HelloWorld from './hello-world';
 
 describe('Hello World', () => {
+  let greeter = new HelloWorld();
+
   it('says hello', () => {
-    expect(helloWorld()).toEqual('Hello, World!');
+    expect(greeter.hello()).toEqual('Hello, World!');
   });
 });

--- a/exercises/leap/example.js
+++ b/exercises/leap/example.js
@@ -6,5 +6,14 @@
  * @return {boolean}
  * Whether given year is a leap year.
  */
-export default (year) => year % 400 == 0 || year % 4 == 0 && year % 100 != 0;
+class Year {
+  constructor(year) {
+    this.year = year;
+  }
 
+  isLeap() {
+    return this.year % 400 === 0 || this.year % 4 === 0 && this.year % 100 !== 0;
+  }
+}
+
+export default Year;

--- a/exercises/leap/leap.spec.js
+++ b/exercises/leap/leap.spec.js
@@ -1,40 +1,48 @@
-import isLeapYear from './leap';
+import Year from './leap';
 
 describe('A leap year', () => {
 
   it('is not very common', () => {
-    expect(isLeapYear(2015)).toBeFalsy();
+    let year = new Year(2015);
+    expect(year.isLeap()).toBeFalsy();
   });
 
   xit('is introduced every 4 years to adjust about a day', () => {
-    expect(isLeapYear(2016)).toBeTruthy();
+    let year = new Year(2016);
+    expect(year.isLeap()).toBeTruthy();
   });
 
   xit('is skipped every 100 years to remove an extra day', () => {
-    expect(isLeapYear(1900)).toBeFalsy();
+    let year = new Year(1900);
+    expect(year.isLeap()).toBeFalsy();
   });
 
   xit('is reintroduced every 400 years to adjust another day', () => {
-    expect(isLeapYear(2000)).toBeTruthy();
+    let year = new Year(2000);
+    expect(year.isLeap()).toBeTruthy();
   });
 
   // Feel free to enable the following tests to check some more examples
   xdescribe('Additional example of a leap year that', () => {
 
     it('is not a leap year', () => {
-      expect(isLeapYear(1978)).toBeFalsy();
+      let year = new Year(1978);
+      expect(year.isLeap()).toBeFalsy();
     });
 
     it('is a common leap year', () => {
-      expect(isLeapYear(1992)).toBeTruthy();
+      let year = new Year(1992);
+      expect(year.isLeap()).toBeTruthy();
     });
 
     it('is skipped every 100 years', () => {
-      expect(isLeapYear(2100)).toBeFalsy();
+      let year = new Year(2100);
+      expect(year.isLeap()).toBeFalsy();
     });
 
     it('is reintroduced every 400 years', () => {
-      expect(isLeapYear(2400)).toBeTruthy();
+      let year = new Year(2400);
+      expect(year.isLeap()).toBeTruthy();
     });
 
   });

--- a/exercises/leap/leap.spec.js
+++ b/exercises/leap/leap.spec.js
@@ -2,49 +2,24 @@ import Year from './leap';
 
 describe('A leap year', () => {
 
-  it('is not very common', () => {
+  it('year not divisible by 4: common year', () => {
     let year = new Year(2015);
     expect(year.isLeap()).toBeFalsy();
   });
 
-  xit('is introduced every 4 years to adjust about a day', () => {
+  xit('year divisible by 4, not divisible by 100: leap year', () => {
     let year = new Year(2016);
     expect(year.isLeap()).toBeTruthy();
   });
 
-  xit('is skipped every 100 years to remove an extra day', () => {
-    let year = new Year(1900);
+  xit('year divisible by 100, not divisible by 400: common year', () => {
+    let year = new Year(2100);
     expect(year.isLeap()).toBeFalsy();
   });
 
-  xit('is reintroduced every 400 years to adjust another day', () => {
+  xit('year divisible by 400: leap year', () => {
     let year = new Year(2000);
     expect(year.isLeap()).toBeTruthy();
-  });
-
-  // Feel free to enable the following tests to check some more examples
-  xdescribe('Additional example of a leap year that', () => {
-
-    it('is not a leap year', () => {
-      let year = new Year(1978);
-      expect(year.isLeap()).toBeFalsy();
-    });
-
-    it('is a common leap year', () => {
-      let year = new Year(1992);
-      expect(year.isLeap()).toBeTruthy();
-    });
-
-    it('is skipped every 100 years', () => {
-      let year = new Year(2100);
-      expect(year.isLeap()).toBeFalsy();
-    });
-
-    it('is reintroduced every 400 years', () => {
-      let year = new Year(2400);
-      expect(year.isLeap()).toBeTruthy();
-    });
-
   });
 
 });


### PR DESCRIPTION
* As per @rchavarria's comment https://github.com/exercism/xecmascript/issues/274#issuecomment-297439261, do not make users switch between classes and functions for solutions. Only `hello-world` and `leap` exercises were expecting functions, convert their specs to expect classes instead.
* Also took the opportunity to remove some specs from `leap` as per the `x-common`. Keep only what are absolute necessary.

Kept the commits separate since I think they do different things.