### PR TITLE
Throw error for invalid input of perfect-numbers

### DIFF
--- a/exercises/perfect-numbers/example.js
+++ b/exercises/perfect-numbers/example.js
@@ -42,7 +42,7 @@ export default class PerfectNumbers {
 
     // Check if the input is valid
     if (number <= 0) {
-      return 'Classification is only possible for natural numbers.';
+      throw new Error('Classification is only possible for natural numbers.');
     }
 
     // Factorize the current number.

--- a/exercises/perfect-numbers/perfect-numbers.spec.js
+++ b/exercises/perfect-numbers/perfect-numbers.spec.js
@@ -63,11 +63,13 @@ describe('Exercise - Perfect Numbers', () => {
   describe('Invalid Inputs', () => {
 
     xit('Zero is rejected (not a natural number)', () => {
-      expect(perfectNumbers.classify(0)).toEqual('Classification is only possible for natural numbers.');
+      expect(() => perfectNumbers.classify(0))
+        .toThrow('Classification is only possible for natural numbers.');
     });
 
     xit('Negative integer is rejected (not a natural number)', () => {
-      expect(perfectNumbers.classify(-1)).toEqual('Classification is only possible for natural numbers.');
+      expect(() => perfectNumbers.classify(-1))
+        .toThrow('Classification is only possible for natural numbers.');
     });
 
   });


### PR DESCRIPTION
The [canonical-data](https://github.com/exercism/x-common/blob/master/exercises/perfect-numbers/canonical-data.json#L86-L106) says it should be an error. Raise an error instead of just returning
the string.