### PR TITLE
Use local jest instead of global in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ sudo: false
 script:
 - bin/fetch-configlet
 - bin/configlet .
-- npm install
 - make test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-assignment:
 	@cp exercises/$(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
 	@cp exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(subst _,-,$(ASSIGNMENT)).$(FILEEXT)
 	@sed 's/xit/it/g' exercises/$(ASSIGNMENT)/$(TSTFILE) > $(OUTDIR)/temp.$(TSTFILE)
-	@jest $(OUTDIR)/temp.*.spec.js
+	@node_modules/.bin/jest $(OUTDIR)/temp.*.spec.js
 	@rm $(OUTDIR)/*
 	@rmdir $(OUTDIR)
 


### PR DESCRIPTION
The Makefile was relying on global installation of jest to run the
tests. This failed for me since I did not have jest globally
installed. Also the README does not mention about installing globally
which is anyways not a good idea (might cause issues due to different versions).

Hence, change Makefile to use locally installed jest instead.