### PR TITLE
Simplify ESLint configuration by extending a default set of rules

### DIFF
--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/all-your-base/package.json
+++ b/exercises/all-your-base/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/binary-search/example.js
+++ b/exercises/binary-search/example.js
@@ -9,7 +9,9 @@ function isSortedArray(array) {
 }
 
 function recursiveSearch(array, value, start, end) {
-  if (start === end) return -1;
+  if (start === end) {
+    return -1;
+  }
 
   const mid = Math.floor((start + end) / 2);
   if (array[mid] > value) {

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/bob/bob.js
+++ b/exercises/bob/bob.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 //
 // This is only a SKELETON file for the 'Bob' exercise. It's been provided as a
 // convenience to get you started writing code faster.

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/connect/example.js
+++ b/exercises/connect/example.js
@@ -36,7 +36,10 @@ export default class {
     const matches = this.neighbors(pos).filter(({x,y}) => {
       return this.matches({x,y}, XorO) && checked.filter((spot) => spot.x === x && spot.y === y).length === 0;
     });
-    if(matches.length === 0) return false;
+    if(matches.length === 0) {
+     return false;
+    }
+
     return matches.filter(spot => this.search(spot, XorO, checked)).length > 0;
   }
   neighbors({x,y}) {

--- a/exercises/connect/package.json
+++ b/exercises/connect/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^19.0.0",
-    "babel-preset-env": "^1.3.3",
+    "babel-jest": "^20.0.1",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
-    "jest": "^19.0.2"
+    "jest": "^20.0.1"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/diamond/example.js
+++ b/exercises/diamond/example.js
@@ -9,7 +9,7 @@ export default class Diamond {
     for(i = inputIndex - 1; i >= 0; i--){
       output += getLine(inputIndex, i);
     }
-    return output; 
+    return output;
   }
 }
 
@@ -22,9 +22,8 @@ function printAlphabets(index) {
   var character = 65 + index;
   if(index === 0){
     return "A";
-  }
-  else {
-    return String.fromCharCode(character) + spaceTimes((index - 1) * 2 + 1) + String.fromCharCode(character); 
+  } else {
+    return String.fromCharCode(character) + spaceTimes((index - 1) * 2 + 1) + String.fromCharCode(character);
   }
 }
 

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/grains/lib/big-integer.js
+++ b/exercises/grains/lib/big-integer.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // copied from https://github.com/peterolson/BigInteger.js/blob/master/BigInteger.js
 // commit: https://github.com/peterolson/BigInteger.js/commit/58375195b3bc12475cb382b165ba251766a3614e#diff-82f314e495f1c3ec2a3bc0602627d16a
 var bigInt = (function (undefined) {

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/hexadecimal/package.json
+++ b/exercises/hexadecimal/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/largest-series-product/example.js
+++ b/exercises/largest-series-product/example.js
@@ -1,7 +1,10 @@
 export default class Series {
 
   constructor(numberString) {
-    if(numberString.match('[^0-9]')) throw new Error('Invalid input.');
+    if(numberString.match('[^0-9]')) {
+      throw new Error('Invalid input.');
+    }
+
     this.numberString = numberString;
     this.digits = this.getDigits();
   }
@@ -13,7 +16,10 @@ export default class Series {
   }
 
   largestProduct(size) {
-    if (size < 0) throw new Error('Invalid input.');
+    if (size < 0) {
+      throw new Error('Invalid input.');
+    }
+
     let product,
       max = 0;
     this.slices(size).forEach( slice => {

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/linked-list/package.json
+++ b/exercises/linked-list/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/meetup/example.js
+++ b/exercises/meetup/example.js
@@ -1,7 +1,7 @@
 export default function meetupDay (year, month, dayOfWeek, which) {
 
   let candidates = getCandidates(year, month, dayOfWeek);
-  let d, i, res;
+  let res;
 
   which = which.toLowerCase();
 
@@ -9,11 +9,9 @@ export default function meetupDay (year, month, dayOfWeek, which) {
     res = find(candidates, d =>  {
       return 13 <= d.getDate() && d.getDate() <= 19;
     });
-  }
-  else if (which === 'last') {
+  } else if (which === 'last') {
     res = candidates.pop();
-  }
-  else {
+  } else {
     which = parseInt(which) - 1;
     res = candidates.slice(which, which + 1).pop();
   }

--- a/exercises/meetup/meetup.spec.js
+++ b/exercises/meetup/meetup.spec.js
@@ -1,11 +1,7 @@
 import meetupDay from './meetup';
 
-function MeetupDayException(message) {
-  this.message = message;
-  this.name = 'MeetupDayException';
-}
-
 describe('meetupDay()', () => {
+
   it('test monteenth of may 2013', () => {
     expect(meetupDay(2013, 4, 'Monday', 'teenth')).toEqual(new Date(2013, 4, 13));
   });
@@ -59,4 +55,5 @@ describe('meetupDay()', () => {
       meetupDay(2015, 1, 'Monday', '5th');
     }).toThrow();
   });
+
 });

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/octal/package.json
+++ b/exercises/octal/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/package.json
+++ b/exercises/package.json
@@ -9,10 +9,10 @@
     "url": "https://github.com/exercism/xecmascript"
   },
   "devDependencies": {
-    "babel-jest": "^19.0.0",
-    "babel-preset-env": "^1.3.3",
+    "babel-jest": "^20.0.1",
+    "babel-preset-env": "^1.4.0",
     "eslint": "^3.19.0",
-    "jest": "^19.0.2"
+    "jest": "^20.0.1"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
     "lint": "eslint *.js; exit 0;",
     "lint-test": "eslint *.js && jest --no-cache ./* "
   },
@@ -34,44 +35,27 @@
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off"
     }
   },
   "licenses": [

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/perfect-numbers/example.js
+++ b/exercises/perfect-numbers/example.js
@@ -14,7 +14,7 @@ export default class PerfectNumbers {
     // Accepts only natural numbers greater than 1.
     if (number <= 1) {
       return divs;
-  	}
+    }
 
     // 1 always divides everyone!
     divs.push(1);
@@ -24,7 +24,7 @@ export default class PerfectNumbers {
 
       if (number % i === 0) {
         divs.push(i);
-  		}
+      }
     }
 
     return divs;
@@ -38,7 +38,7 @@ export default class PerfectNumbers {
    */
   classify(number) {
 
-    let i, sum, result;
+    let sum, result;
 
     // Check if the input is valid
     if (number <= 0) {
@@ -54,11 +54,9 @@ export default class PerfectNumbers {
     // Check if the number is perfect.
     if (sum === number) {
       result = 'perfect';
-    }
-    else if (sum > number) {
+    } else if (sum > number) {
       result = 'abundant';
-    }
-    else {
+    } else {
       result = 'deficient';
     }
 

--- a/exercises/perfect-numbers/package.json
+++ b/exercises/perfect-numbers/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/queen-attack/queen-attack.spec.js
+++ b/exercises/queen-attack/queen-attack.spec.js
@@ -17,11 +17,10 @@ describe('Queens', () => {
     const positioning = {white: [2,4], black: [2,4]};
 
     try {
-      const queens = new Queens(positioning);
+      new Queens(positioning);
     } catch(error) {
       expect(error).toEqual('Queens cannot share the same space');
     }
-
   });
 
   xit('toString representation', () => {

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/rna-transcription/example.js
+++ b/exercises/rna-transcription/example.js
@@ -12,8 +12,7 @@ export default class Transcriptor {
     if (rna.length !== dna.length) {
       // invalid characters in the strand
       throw new Error('Invalid input DNA.');
-    }
-    else {
+    } else {
       return rna;
     }
   }

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/robot-name/package.json
+++ b/exercises/robot-name/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/saddle-points/example.js
+++ b/exercises/saddle-points/example.js
@@ -13,7 +13,7 @@ export default class Matrix {
   constructor(data) {
     this.rows = [];
     this.columns = [];
-    data.split(/\n/).map((row, ii) => {
+    data.split(/\n/).map((row) => {
       this.rows.push(row.trim().split(/\s/).map((cell, jj) => {
         this.columns[jj] ? this.columns[jj].push(+cell) : this.columns[jj] = [+cell];
         return +cell;

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/sieve/example.js
+++ b/exercises/sieve/example.js
@@ -12,7 +12,7 @@ function indivisibleBy(value) {
 }
 
 function sieve(n) {
-  let i, prime, possibilities;
+  let prime, possibilities;
   const primes = [];
 
   possibilities = newArrayWithRange(2, n);

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [

--- a/package.json
+++ b/package.json
@@ -27,52 +27,38 @@
   "scripts": {
     "test": "jest --no-cache ./*",
     "watch": "jest --no-cache --watch ./*",
-    "lint": "eslint *.js; exit 0;",
-    "lint-test": "eslint *.js && jest --no-cache ./* "
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
     "parserOptions": {
       "ecmaVersion": 6,
       "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "node": true,
+      "jasmine": true
+    },
+    "extends": "eslint:recommended",
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-cond-assign": [
-        2,
-        "always"
-      ],
-      "no-console": 2,
-      "no-constant-condition": 2,
-      "no-control-regex": 2,
-      "no-debugger": 2,
-      "no-dupe-args": 2,
-      "no-dupe-keys": 2,
-      "no-duplicate-case": 2,
-      "no-empty-character-class": 2,
-      "no-empty": 2,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 2,
-      "no-extra-parens": 2,
-      "no-extra-semi": 2,
-      "no-func-assign": 2,
-      "no-inner-declarations": [
-        2,
-        "both"
-      ],
-      "no-invalid-regexp": 2,
-      "no-irregular-whitespace": 2,
-      "no-negated-in-lhs": 2,
-      "no-obj-calls": 2,
-      "no-regex-spaces": 2,
-      "no-sparse-arrays": 2,
-      "no-unexpected-multiline": 2,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 2,
-      "valid-typeof": 2
+      "indent": [ "off", 2 ],
+      "block-scoped-var": "off",
+      "radix": "off",
+      "no-use-before-define": "off",
+      "one-var": [ "off", "always" ],
+      "quotes": [ "off", "single", { "avoidEscape": true } ],
+      "semi": [ "off", "always" ],
+      "semi-spacing": [ "off", { "before": false, "after": true } ],
+      "no-whitespace-before-property": "off",
+      "space-before-blocks": [ "off", "always" ],
+      "space-before-function-paren": [ "off", { "anonymous": "always", "named": "never" } ],
+      "keyword-spacing": [ "off", { "before": true, "after": true } ],
+      "no-multi-spaces": "off",
+      "no-trailing-spaces": "off",
+      "curly": [ "error", "all" ],
+      "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+      "object-curly-spacing": [ "off", "always" ]
     }
   },
   "licenses": [


### PR DESCRIPTION
This PR creates a complete ESLint configuration, based on a default set of rules provided by ESLint itself.

Then, some rules are disabled becaused they report a relative big number of errors and I prefer discussing them before spending time fixing them (just in case we decide we don't want those rules).

Anyway, some reported errors are fixed, but not too many.

Maybe, this PR has conflicts, because it modifies `package.json` (and `package.json` on each individual exercise), but I'd like to start discussing ESLint rules.